### PR TITLE
ローカルのBGMのロード処理の修正

### DIFF
--- a/Assets/uDesktopMascot/Scripts/BGMController.cs
+++ b/Assets/uDesktopMascot/Scripts/BGMController.cs
@@ -79,8 +79,6 @@ namespace uDesktopMascot
                     } else
                     {
                         Log.Debug("BGMを {0} 件ロードしました。", count);
-                        // ロード完了後に最初のBGMを再生開始
-                        PlayNextBGM();
                     }
                 },
                 () =>
@@ -99,6 +97,7 @@ namespace uDesktopMascot
         {
             if (!_bgmLoaded || bgmClips.Count == 0)
             {
+                Log.Warning("BGMがロードされていないか、BGMが存在しません。");
                 return;
             }
 

--- a/Assets/uDesktopMascot/Scripts/Utility/SoundUtility.cs
+++ b/Assets/uDesktopMascot/Scripts/Utility/SoundUtility.cs
@@ -34,11 +34,18 @@ namespace uDesktopMascot
             // フォルダが存在する場合
             if (Directory.Exists(folderPath))
             {
-                // 既存のサウンドリストをクリア
-                soundList.Clear();
-
                 // フォルダ内のすべてのファイルを取得
                 var files = Directory.GetFiles(folderPath);
+
+                if (files.Length == 0)
+                {
+                    // フォルダ内にファイルが存在しない場合
+                    onDirectoryNotFound?.Invoke();
+                    return;
+                }
+                
+                // 既存のサウンドリストをクリア
+                soundList.Clear();
 
                 foreach (var filePath in files)
                 {


### PR DESCRIPTION
# fix
* BGMフォルダにBGMがない場合、デフォルトのBGMが再生されなくなっていた