### PR TITLE
デスクトップ上のマウスカーソルポジション取得処理の追加

### DIFF
--- a/Assets/uDesktopMascot/Scripts/ExplorerWindowDetector.cs
+++ b/Assets/uDesktopMascot/Scripts/ExplorerWindowDetector.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -49,7 +49,8 @@ namespace uDesktopMascot
         public static float GetDPIScale()
         {
             IntPtr hdc = GetDC(IntPtr.Zero);
-            try{
+            try
+            {
                 int dpiX = GetDeviceCaps(hdc, LOGPIXELSX);
                 int dpiY = GetDeviceCaps(hdc, LOGPIXELSY);
 

--- a/Assets/uDesktopMascot/Scripts/Manager/CharacterController.cs
+++ b/Assets/uDesktopMascot/Scripts/Manager/CharacterController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using Unity.Logging;
@@ -135,8 +135,8 @@ namespace uDesktopMascot
 
 #if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
 
-            // モデルのスクリーン座標を取得
-            var modelScreenPos = ScreenUtility.GetModelScreenPosition(_mainCamera, _model.transform);
+            // デスクトップ上のマウスカーソル座標を取得
+            var cursorPos = MouseUtility.GetCursorPosition();
 
             // エクスプローラーウィンドウの位置を取得
             var explorerWindows = ExplorerWindowDetector.GetExplorerWindows();
@@ -157,10 +157,10 @@ namespace uDesktopMascot
                 rect.right = (int)(rect.right / dpiScale);
                 rect.bottom = (int)(rect.bottom / dpiScale);
 
-                // モデルがウィンドウの上部付近にいるか判定（例：ウィンドウの上端から50ピクセル以内）
-                if (modelScreenPos.x >= rect.left && modelScreenPos.x <= rect.right)
+                // マウスがウィンドウの上部付近にいるか判定（例：ウィンドウの上端から50ピクセル以内）
+                if (cursorPos.x >= rect.left && cursorPos.x <= rect.right)
                 {
-                    if (modelScreenPos.y >= rect.top - 50 && modelScreenPos.y <= rect.top + 50)
+                    if (cursorPos.y >= rect.top - 50 && cursorPos.y <= rect.top + 50)
                     {
                         isNearExplorerTop = true;
                         break;

--- a/Assets/uDesktopMascot/Scripts/Utility/MouseUtility.cs
+++ b/Assets/uDesktopMascot/Scripts/Utility/MouseUtility.cs
@@ -1,0 +1,37 @@
+﻿using UnityEngine;
+using System.Runtime.InteropServices;
+
+namespace uDesktopMascot
+{
+    /// <summary>
+    /// Windows上のマウスに関するユーティリティクラス
+    /// </summary>
+    public static class MouseUtility
+    {
+        /// <summary>
+        /// マウスポインタのポジション格納用(WindowsAPI呼び出しで使用)
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct POINT
+        {
+            public int X;
+            public int Y;
+        }
+
+        [DllImport("user32.dll")]
+        private static extern bool GetCursorPos(out POINT lpPoint);
+
+        /// <summary>
+        /// マウスポインタの位置を取得する
+        /// </summary>
+        public static Vector2 GetCursorPosition()
+        {
+            if (!GetCursorPos(out POINT point))
+            {
+                return Vector2.zero;
+            }
+
+            return new Vector2(point.X, point.Y);
+        }
+    }
+}

--- a/Assets/uDesktopMascot/Scripts/Utility/MouseUtility.cs.meta
+++ b/Assets/uDesktopMascot/Scripts/Utility/MouseUtility.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3e867f52e271cec43be0e5df637bbbcb


### PR DESCRIPTION
エクスプローラの上部を判定するために、マウス座標を取得するユーティリティを追加しました。
判定処理も、これを使用したものに修正しました。
ウインドウが重なってても上部判定がされてしまうため、別途修正が必要です。
現状はエクスプローラだけですが、他のウインドウは対象としないのでしょうか？