### PR TITLE
fix: モデルが描画範囲の中心になるようカメラ位置を調整

### DIFF
--- a/Assets/uDesktopMascot/Scenes/SampleScene.unity
+++ b/Assets/uDesktopMascot/Scenes/SampleScene.unity
@@ -629,7 +629,7 @@ Transform:
   m_GameObject: {fileID: 519420028}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalPosition: {x: 0, y: 2.5, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []


### PR DESCRIPTION
腕を上げているとき、手が見切れていたので、カメラの位置をずらして収めました。

![image](https://github.com/user-attachments/assets/437b9c72-8366-4350-9ac5-5f529fe71c63)
