### PR TITLE
GameCIでビルド時に生成されるファイルの名前を`uDesktopMascot`になるように修正した

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,11 +76,9 @@ jobs:
           - targetPlatform: StandaloneWindows64
             runsOn: windows-latest
             modules: windows-il2cpp
-            buildName: uDesktopMascot
           - targetPlatform: StandaloneOSX
             runsOn: macos-latest
             modules: mac-il2cpp
-            buildName: uDesktopMascot
 
     steps:
       - name: Check out my unity project.
@@ -122,6 +120,7 @@ jobs:
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
           unityVersion: ${{ matrix.unityVersion }}
+          buildName: 'uDesktopMascot'
 
       - name: Upload the Build for ${{ matrix.targetPlatform }}
         uses: actions/upload-artifact@v4.6.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,7 @@ jobs:
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
           unityVersion: ${{ matrix.unityVersion }}
+          build-name: 'uDesktopMascot'
           buildName: 'uDesktopMascot'
 
       - name: Upload the Build for ${{ matrix.targetPlatform }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,9 +124,8 @@ jobs:
 
       - name: ビルド成果物を圧縮して名前を変更
         run: |
-          REPO_NAME="${GITHUB_REPOSITORY##*/}"
           cd build
-          mv "${{ matrix.targetPlatform }}" "${REPO_NAME}"
+          mv "${{ matrix.targetPlatform }}" "uDesktopMascot"
           cd ..
 
       - name: Upload the Build for ${{ matrix.targetPlatform }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,11 @@ jobs:
           - targetPlatform: StandaloneWindows64
             runsOn: windows-latest
             modules: windows-il2cpp
+            buildName: uDesktopMascot
           - targetPlatform: StandaloneOSX
             runsOn: macos-latest
             modules: mac-il2cpp
+            buildName: uDesktopMascot
 
     steps:
       - name: Check out my unity project.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           buildName: 'uDesktopMascot'
 
-      - name: ビルド成果物を圧縮して名前を変更
+      - name: Change build folder name
         run: |
           cd build
           mv "${{ matrix.targetPlatform }}" "uDesktopMascot"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,13 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           buildName: 'uDesktopMascot'
 
+      - name: ビルド成果物を圧縮して名前を変更
+        run: |
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          cd build
+          mv "${{ matrix.targetPlatform }}" "${REPO_NAME}"
+          cd ..
+
       - name: Upload the Build for ${{ matrix.targetPlatform }}
         uses: actions/upload-artifact@v4.6.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,6 @@ jobs:
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
           unityVersion: ${{ matrix.unityVersion }}
-          build-name: 'uDesktopMascot'
           buildName: 'uDesktopMascot'
 
       - name: Upload the Build for ${{ matrix.targetPlatform }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -160,6 +160,7 @@ jobs:
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
           unityVersion: ${{ matrix.unityVersion }}
+          buildName: 'uDesktopMascot'
 
       - name: ビルド成果物を圧縮して名前を変更
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -165,6 +165,7 @@ jobs:
       - name: ビルド成果物を圧縮して名前を変更
         run: |
           cd build
+          mv "${{ matrix.targetPlatform }}" "uDesktopMascot"
           zip -r "${{ steps.build_info.outputs.artifact_name }}.zip" *
           cd ..
           mv "build/${{ steps.build_info.outputs.artifact_name }}.zip" "./${{ steps.build_info.outputs.artifact_name }}.zip"

--- a/setup.iss
+++ b/setup.iss
@@ -53,3 +53,4 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+

--- a/setup.iss
+++ b/setup.iss
@@ -43,8 +43,8 @@ Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "build\StandaloneWindows64\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "build\StandaloneWindows64\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "build\{#MyAppName}\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "build\{#MyAppName}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]

--- a/setup.iss
+++ b/setup.iss
@@ -4,7 +4,7 @@
 #define MyAppName "uDesktopMascot"
 #define MyAppPublisher "MidraLab"
 #define MyAppURL "https://midralab.github.io/uDesktopMascot/"
-#define MyAppExeName "StandaloneWindows64.exe"
+#define MyAppExeName "uDesktopMascot.exe"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
@@ -43,8 +43,8 @@ Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "build\StandaloneWindows64\StandaloneWindows64.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "build\StandaloneWindows64\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "build\{#MyAppName}\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "build\{#MyAppName}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]

--- a/setup.iss
+++ b/setup.iss
@@ -43,8 +43,8 @@ Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "build\{#MyAppName}\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "build\{#MyAppName}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "build\StandaloneWindows64\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "build\StandaloneWindows64\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]
@@ -53,4 +53,3 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
-

--- a/setup.iss
+++ b/setup.iss
@@ -43,8 +43,8 @@ Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "build\{#MyAppName}\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "build\{#MyAppName}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "build\StandaloneWindows64\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "build\StandaloneWindows64\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]


### PR DESCRIPTION
## 概要

GameCIでビルド時に生成されるファイルの名前を`uDesktopMascot`になるように修正した

## 変更内容

- ビルド後の成果物が以前は`StandaloneWindows64`だったが`uDesktopMascot`名で出力されるように設定した。
- それに合わせて`setup.iss`でのビルド物の指定パスを変更した

## 検証手順

以下のリンクからインストーラー版じゃない方をダウンロードしてフォルダの中身を確認する。
https://github.com/MidraLab/uDesktopMascot/actions/runs/12852592757

結果
![image](https://github.com/user-attachments/assets/1ad1ba23-45a9-415b-b4e9-88ee5c2b17cd)
