### PR TITLE
特定のVRMでビルドした後のバイナリでロードできない問題の対応

### DIFF
--- a/Assets/uDesktopMascot/Scripts/Common/Singleton.cs
+++ b/Assets/uDesktopMascot/Scripts/Common/Singleton.cs
@@ -12,32 +12,27 @@ namespace uDesktopMascot
         private static T _instance;
         private static readonly object _lock = new();
         
+#if UNITY_EDITOR
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void DomainReset()
         {
             Log.Debug("[Singleton<" + typeof(T).Name + ">] DomainReset called.");
             _instance = null;
         }
+#endif
 
         public static T Instance
         {
             get
             {
-                Log.Debug("[Singleton<" + typeof(T).Name + ">] Instance getter called.");
-                if (_instance == null)
+                if (_instance != null)
                 {
-                    lock (_lock)
-                    {
-                        if (_instance == null)
-                        {
-                            Log.Debug("[Singleton<" + typeof(T).Name + ">] Creating new instance.");
-                            _instance = new T();
-                        }
-                    }
+                    return _instance;
                 }
-                else
+
+                lock (_lock)
                 {
-                    Log.Debug("[Singleton<" + typeof(T).Name + ">] Returning existing instance.");
+                    _instance ??= new T();
                 }
                 return _instance;
             }

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -38,6 +38,7 @@ GraphicsSettings:
   - {fileID: 4800000, guid: df12117ecd77c31469c224178886498e, type: 3}
   - {fileID: 4800000, guid: 165365ab7100a044ca85fc8c33548a62, type: 3}
   - {fileID: 4800000, guid: 3c79b10c7e0b2784aaa4c2f8dd17d55e, type: 3}
+  - {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}


### PR DESCRIPTION
# 原因

モデルによってはMToonが使えず standard shaderが使われていた

# 対応

standard shaderをストリッピングされないように追加