### PR TITLE
ビルド時にデバッグ用のフォルダの削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,6 @@ sysinfo.txt
 
 # End of https://www.toptal.com/developers/gitignore/api/unity,rider
 
-uDesktopMascot.zip
+uDesktopMascot*.zip
 uDesktopMascotBuild/*
 .vscode/*

--- a/Assets/uDesktopMascot/Editor/PostBuildProcessor.cs
+++ b/Assets/uDesktopMascot/Editor/PostBuildProcessor.cs
@@ -11,6 +11,9 @@ using CompressionLevel = System.IO.Compression.CompressionLevel;
 
 namespace uDesktopMascot.Editor
 {
+    /// <summary>
+    /// ビルド後処理を行うクラス
+    /// </summary>
     public sealed class PostBuildProcessor : IPostprocessBuildWithReport
     {
         // コールバックの順序を指定
@@ -254,23 +257,13 @@ namespace uDesktopMascot.Editor
             }
 
             // 削除対象のフォルダをリスト化
-            var foldersToDelete = new List<string>();
+            var foldersToDelete = new List<string>
+            {
+                Path.Combine(outputDirectory,
+                    $"{productName}_BackUpThisFolder_ButDontShipItWithYourGame"),
+                Path.Combine(outputDirectory, $"{productName}_BurstDebugInformation_DoNotShip")
+            };
 
-            if (target == BuildTarget.StandaloneWindows || target == BuildTarget.StandaloneWindows64)
-            {
-                // Windowsの場合
-                foldersToDelete.Add(Path.Combine(outputDirectory,
-                    $"{productName}_BackUpThisFolder_ButDontShipItWithYourGame"));
-                foldersToDelete.Add(Path.Combine(outputDirectory, $"{productName}_BurstDebugInformation_DoNotShip"));
-            } else if (target == BuildTarget.StandaloneOSX)
-            {
-                // Macの場合：アプリケーションパッケージ内のパスを指定
-                foldersToDelete.Add(Path.Combine(outputPath, "Contents", "Resources",
-                    $"{productName}BackUpThisFolder_ButDontShipItWithYourGame"));
-                foldersToDelete.Add(
-                    Path.Combine(outputPath, "Contents", "Resources", $"{productName}_BurstDebugInformation_DoNotShip"));
-            }
-            // 必要に応じて他のプラットフォームを追加
 
             bool folderDeleted = false;
 


### PR DESCRIPTION
https://baba-s.hatenablog.com/entry/2022/02/08/090000
https://note.com/daiki_all/n/n84c9e470696e

# その他
fix #85 

# 既知の不具合
* zipの中にzipフォルダが入っている
* macのビルドが失敗している
→ 別のPRで対応