### PR TITLE
macOS向けビルドで実行ファイルに実行フラグを付与する

### DIFF
--- a/Assets/uDesktopMascot/Editor/PostBuildProcessor.cs
+++ b/Assets/uDesktopMascot/Editor/PostBuildProcessor.cs
@@ -38,6 +38,8 @@ namespace uDesktopMascot.Editor
             // アプリケーション名を取得
             var appName = Path.GetFileNameWithoutExtension(pathToBuiltProject);
 
+            SetExecPermissionForMacOS(buildDirectory, appName);
+
             // プラットフォームに応じた StreamingAssets のパスを取得
             var streamingAssetsPath = GetStreamingAssetsPath(target, buildDirectory, appName);
             if (string.IsNullOrEmpty(streamingAssetsPath))
@@ -204,5 +206,26 @@ namespace uDesktopMascot.Editor
                 .ToString()
                 .Replace('/', Path.DirectorySeparatorChar));
         }
+
+        /// <summary>
+        ///     実行パーミッションを設定する
+        /// </summary>
+        /// <param name="buildDirectory">ビルドディレクトリのパス</param>
+        /// <param name="appName">アプリケーション名</param>
+        private static void SetExecPermissionForMacOS(string buildDirectory, string appName)
+        {
+#if UNITY_OSX_EDITOR
+            var execPath = Path.Combine(buildDirectory, $"{appName}.app", "Contents", "MacOS", "uDesktopMascot");
+            if (File.Exists(execPath))
+            {
+                sys_chmod(execPath, 0x775);
+            }
+#endif
+        }
+
+#if UNITY_OSX_EDITOR
+        [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
+        private static extern int sys_chmod(string path, uint mode);
+#endif
     }
 }

--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ QualityLevel=2
 
 </details>
 
+## macOSでの実行について
+
+macOSでアプリを実行する際、GateKeeperによってアプリがブロックされる場合があります。
+その場合、ターミナルから以下のコマンドを実行してください。
+
+```sh
+xattr -r -c uDesktopMascot.app
+```
+
 ## requirements
 * Unity 6000.0.31f1(IL2CPP)
 


### PR DESCRIPTION
macOS向けビルドで実行フラグがないためアプリを実行できないためパーミッションを付与します。
https://discussions.unity.com/t/mac-unity-build-from-a-pc-not-opening-on-mac/803627

また、セキュリティ強化によっても実行できないためフラグを削除するコマンドをREADMEに追記しています。
