### PR TITLE
setup.issフォイルのバージョンを直接変更する形に修正。リリースワークフロー修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,10 +125,14 @@ jobs:
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
+          
+          # リモートの最新変更を取得してリベース
+          git fetch origin
+          git rebase origin/${{ github.ref_name }}
+          
           git add setup.iss
           if ! git diff --cached --quiet; then
             git commit -m "Update setup.iss"
-            git pull origin ${{ github.ref_name }} --rebase
             git push origin HEAD:${{ github.ref }}
           else
             echo "No changes to setup.iss, skipping commit and push"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
           
           # リモートの最新変更を取得してリベース
           git fetch origin
-          git rebase origin/${{ github.ref_name }}
+          git rebase origin/${{ github.ref_name }} --autostash
           
           git add setup.iss
           if ! git diff --cached --quiet; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,18 @@ jobs:
           versioning: Custom
           version: ${{ needs.check-branch.outputs.current_version }}
 
+      - name: Git Push setup.iss
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+          git add setup.iss
+          if ! git diff --cached --quiet; then
+            git commit -m "Update setup.iss"
+            git push
+          else
+            echo "No changes to setup.iss, skipping commit and push"
+          fi
+
       - name: Change build folder name
         run: |
           cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
           versioning: Custom
           version: ${{ needs.check-branch.outputs.current_version }}
 
-      - name: Git Push setup.iss
+      - name: Update setup.iss
         shell: bash
         run: |
           git config --global user.name "github-actions"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,7 @@ jobs:
           version: ${{ needs.check-branch.outputs.current_version }}
 
       - name: Git Push setup.iss
+        shell: bash
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           fi
 
   build-windows:
-    if: ${{ github.event_name == 'pull_request' || inputs.build_windows }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || inputs.build_windows }}
     needs: [check-branch]
     runs-on: windows-latest
     steps:
@@ -157,7 +157,7 @@ jobs:
           path: "uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe"
 
   build-mac:
-    if: ${{ github.event_name == 'pull_request' || inputs.build_mac }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || inputs.build_mac }}
     needs: [check-branch]
     runs-on: macos-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,7 @@ jobs:
           git add setup.iss
           if ! git diff --cached --quiet; then
             git commit -m "Update setup.iss"
+            git pull origin ${{ github.ref_name }} --rebase
             git push origin HEAD:${{ github.ref }}
           else
             echo "No changes to setup.iss, skipping commit and push"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
           git add setup.iss
           if ! git diff --cached --quiet; then
             git commit -m "Update setup.iss"
-            git push
+            git push origin HEAD:${{ github.ref }}
           else
             echo "No changes to setup.iss, skipping commit and push"
           fi

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -197,6 +197,7 @@ jobs:
           path: "uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe"
 
       - name: ビルド成果物を圧縮
+        shell: bash
         run: |
           cd build
           zip -r "uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip" "uDesktopMascot"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -315,13 +315,17 @@ jobs:
           echo "リリースタグ名は '${TAG_NAME}' です"
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
+      - name: アーティファクト構造の確認
+        run: |
+          ls -R ./artifacts
+
       - name: ドラフトリリースを作成し、アーティファクトをアップロード
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.vars.outputs.tag_name }}
           draft: true
           files: |
-            artifacts/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
+            artifacts/uD/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
             artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe
             artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
             artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -211,8 +211,8 @@ jobs:
       - name: Upload the Build for StandaloneWindows64
         uses: actions/upload-artifact@v4.6.0
         with:
-          name: ${{ steps.build_info.outputs.artifact_name }}
-          path: build/uDesktopMascot
+          name: uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
+          path: build/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
 
   build-mac:
     needs: [create-tag, check-branch]
@@ -293,7 +293,7 @@ jobs:
       - name: Upload the Build for StandaloneOSX
         uses: actions/upload-artifact@v4.6.0
         with:
-          name: ${{ steps.build_info.outputs.artifact_name }}
+          name: uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
           path: build/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
 
   release:
@@ -315,19 +315,15 @@ jobs:
           echo "リリースタグ名は '${TAG_NAME}' です"
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
-      - name: アーティファクト構造の確認
-        run: |
-          ls -R ./artifacts
-
       - name: ドラフトリリースを作成し、アーティファクトをアップロード
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.vars.outputs.tag_name }}
           draft: true
           files: |
-            artifacts/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
-            artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe
-            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
-            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
+            artifacts/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
+            artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe
+            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
+            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -179,18 +179,11 @@ jobs:
             echo "No changes to setup.iss, skipping commit and push"
           fi
 
-      - name: ビルド成果物を圧縮して名前を変更
+      - name: ビルド成果物の名前を変更
         run: |
           cd build
           mv "StandaloneWindows64" "uDesktopMascot"
-          zip -r "uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip" "uDesktopMascot"
           cd ..
-
-      - name: Upload the Build for StandaloneWindows64
-        uses: actions/upload-artifact@v4.6.0
-        with:
-          name: ${{ steps.build_info.outputs.artifact_name }}
-          path: build/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
 
       - name: Set up Inno Setup
         uses: Minionguyjpro/Inno-Setup-Action@v1.0.0
@@ -202,6 +195,18 @@ jobs:
         with:
           name: uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}
           path: "uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe"
+
+      - name: ビルド成果物を圧縮
+        run: |
+          cd build
+          zip -r "uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip" "uDesktopMascot"
+          cd ..
+
+      - name: Upload the Build for StandaloneWindows64
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: ${{ steps.build_info.outputs.artifact_name }}
+          path: build/uDesktopMascot
 
   build-mac:
     needs: [create-tag, check-branch]
@@ -256,18 +261,11 @@ jobs:
           versioning: Custom
           version: ${{ needs.check-branch.outputs.current_version }}
 
-      - name: ビルド成果物を圧縮して名前を変更
+      - name: ビルド成果物の名前を変更
         run: |
           cd build
           mv "StandaloneOSX" "uDesktopMascot"
-          zip -r "uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip" "uDesktopMascot"
           cd ..
-
-      - name: Upload the Build for StandaloneOSX
-        uses: actions/upload-artifact@v4.6.0
-        with:
-          name: ${{ steps.build_info.outputs.artifact_name }}
-          path: build/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
 
       - name: Set up Installer
         run: |
@@ -279,6 +277,18 @@ jobs:
         with:
           name: uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}
           path: build/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
+
+      - name: ビルド成果物を圧縮
+        run: |
+          cd build
+          zip -r "uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip" "uDesktopMascot"
+          cd ..
+
+      - name: Upload the Build for StandaloneOSX
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: ${{ steps.build_info.outputs.artifact_name }}
+          path: build/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
 
   release:
     needs: [create-tag, check-branch, build-windows, build-mac]
@@ -306,10 +316,12 @@ jobs:
       - name: ドラフトリリースを作成し、アーティファクトをアップロード
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.vars.outputs.tag_name }}
+          draft: true
           files: |
             artifacts/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
-            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
+            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}/**
             artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe
-            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
+            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}/**
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Upload the Build for StandaloneWindows64
         uses: actions/upload-artifact@v4.6.0
         with:
-          name: uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
+          name: uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}
           path: build/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
 
   build-mac:
@@ -293,7 +293,7 @@ jobs:
       - name: Upload the Build for StandaloneOSX
         uses: actions/upload-artifact@v4.6.0
         with:
-          name: uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
+          name: uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}
           path: build/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
 
   release:
@@ -327,7 +327,7 @@ jobs:
           files: |
             artifacts/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
             artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe
-            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
-            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
+            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
+            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -163,6 +163,11 @@ jobs:
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
+          
+          # リモートの最新変更を取得してリベース
+          git fetch origin
+          git rebase origin/${{ github.ref_name }} --autostash
+          
           git add setup.iss
           if ! git diff --cached --quiet; then
             git commit -m "Update setup.iss"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -302,6 +302,10 @@ jobs:
         with:
           tag_name: ${{ steps.vars.outputs.tag_name }}
           draft: true
-          files: artifacts/**/*
+          files: |
+            artifacts/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}/**
+            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}/**
+            artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}/**
+            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}/**
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -325,9 +325,9 @@ jobs:
           tag_name: ${{ steps.vars.outputs.tag_name }}
           draft: true
           files: |
-            artifacts/uD/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
-            artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe
-            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
-            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
+            artifacts/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
+            artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe
+            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
+            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -295,7 +295,7 @@ jobs:
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
       - name: ドラフトリリースを作成し、アーティファクトをアップロード
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.vars.outputs.tag_name }}
           draft: true

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -297,9 +297,9 @@ jobs:
       - name: ドラフトリリースを作成し、アーティファクトをアップロード
         uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ steps.vars.outputs.tag_name }}
+          tag: ${{ steps.vars.outputs.tag_name }}
           draft: true
-          files: artifacts/**/*
+          assets: artifacts/**/*
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -196,11 +196,16 @@ jobs:
           name: uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}
           path: "uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe"
 
+      - name: Install 7-Zip (Windows)
+        shell: powershell
+        run: |
+          choco install 7zip -y
+
       - name: ビルド成果物を圧縮
-        shell: bash
+        shell: cmd
         run: |
           cd build
-          zip -r "uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip" "uDesktopMascot"
+          "C:\Program Files\7-Zip\7z.exe" a -r "uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip" "uDesktopMascot"
           cd ..
 
       - name: Upload the Build for StandaloneWindows64

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -283,7 +283,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: アーティファクトをダウンロード
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ./artifacts
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -326,8 +326,8 @@ jobs:
           draft: true
           files: |
             artifacts/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
-            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}/**
+            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
             artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe
-            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}/**
+            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -325,9 +325,9 @@ jobs:
           tag_name: ${{ steps.vars.outputs.tag_name }}
           draft: true
           files: |
-            artifacts/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
+            artifacts/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
+            artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe
             artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
-            artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe
             artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -183,13 +183,14 @@ jobs:
         run: |
           cd build
           mv "StandaloneWindows64" "uDesktopMascot"
+          zip -r "uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip" "uDesktopMascot"
           cd ..
 
       - name: Upload the Build for StandaloneWindows64
         uses: actions/upload-artifact@v4.6.0
         with:
           name: ${{ steps.build_info.outputs.artifact_name }}
-          path: build/uDesktopMascot
+          path: build/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
 
       - name: Set up Inno Setup
         uses: Minionguyjpro/Inno-Setup-Action@v1.0.0
@@ -259,13 +260,14 @@ jobs:
         run: |
           cd build
           mv "StandaloneOSX" "uDesktopMascot"
+          zip -r "uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip" "uDesktopMascot"
           cd ..
 
       - name: Upload the Build for StandaloneOSX
         uses: actions/upload-artifact@v4.6.0
         with:
           name: ${{ steps.build_info.outputs.artifact_name }}
-          path: build/uDesktopMascot
+          path: build/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
 
       - name: Set up Installer
         run: |
@@ -304,12 +306,10 @@ jobs:
       - name: ドラフトリリースを作成し、アーティファクトをアップロード
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.vars.outputs.tag_name }}
-          draft: true
           files: |
             artifacts/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
-            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}/**
+            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
             artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe
-            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}/**
+            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -295,7 +295,7 @@ jobs:
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
       - name: ドラフトリリースを作成し、アーティファクトをアップロード
-        uses: softprops/action-gh-release@v2
+        uses: ncipollo/release-action@v1
         with:
           tag_name: ${{ steps.vars.outputs.tag_name }}
           draft: true

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,4 +1,7 @@
-﻿name: Build and Release
+﻿permissions:
+  contents: write
+
+name: Build and Release
 
 on:
   workflow_dispatch:
@@ -294,16 +297,11 @@ jobs:
           echo "リリースタグ名は '${TAG_NAME}' です"
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
-      - name: アーティファクトの内容を確認
-        run: |
-          ls -la ./artifacts
-
       - name: ドラフトリリースを作成し、アーティファクトをアップロード
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.vars.outputs.tag_name }}
           draft: true
           files: artifacts/**/*
-
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -297,15 +297,19 @@ jobs:
           echo "リリースタグ名は '${TAG_NAME}' です"
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
+      - name: アーティファクト構造の確認
+        run: |
+          ls -R ./artifacts
+
       - name: ドラフトリリースを作成し、アーティファクトをアップロード
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.vars.outputs.tag_name }}
           draft: true
           files: |
-            artifacts/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}/**
+            artifacts/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
             artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}/**
-            artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}/**
+            artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe
             artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}/**
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -158,6 +158,19 @@ jobs:
           versioning: Custom
           version: ${{ needs.check-branch.outputs.current_version }}
 
+      - name: Update setup.iss
+        shell: bash
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+          git add setup.iss
+          if ! git diff --cached --quiet; then
+            git commit -m "Update setup.iss"
+            git push origin HEAD:${{ github.ref }}
+          else
+            echo "No changes to setup.iss, skipping commit and push"
+          fi
+
       - name: ビルド成果物を圧縮して名前を変更
         run: |
           cd build

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -294,6 +294,10 @@ jobs:
           echo "リリースタグ名は '${TAG_NAME}' です"
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
+      - name: アーティファクトの内容を確認
+        run: |
+          ls -la ./artifacts
+
       - name: ドラフトリリースを作成し、アーティファクトをアップロード
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -327,7 +327,7 @@ jobs:
           files: |
             artifacts/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_mac_installer_v${{ needs.check-branch.outputs.current_version }}.pkg
             artifacts/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_win64_installer_v${{ needs.check-branch.outputs.current_version }}.exe
-            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
-            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
+            artifacts/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_mac_v${{ needs.check-branch.outputs.current_version }}.zip
+            artifacts/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}/uDesktopMascot_win_v${{ needs.check-branch.outputs.current_version }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -295,11 +295,11 @@ jobs:
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
       - name: ドラフトリリースを作成し、アーティファクトをアップロード
-        uses: ncipollo/release-action@v1
+        uses: softprops/action-gh-release@v2
         with:
-          tag: ${{ steps.vars.outputs.tag_name }}
+          tag_name: ${{ steps.vars.outputs.tag_name }}
           draft: true
-          assets: artifacts/**/*
+          files: artifacts/**/*
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Assets/uDesktopMascot/Editor/PostBuildProcessor.cs
+++ b/Assets/uDesktopMascot/Editor/PostBuildProcessor.cs
@@ -72,7 +72,7 @@ namespace uDesktopMascot.Editor
                 CreateMaxCompressedZipOfBuildFolder(buildDirectory, appName);
 
                 // インストーラーのバージョンファイルを作成
-                CreateInstallerSetupTextFile(buildDirectory);
+                UpdateSetupFileWithProjectVersion(buildDirectory);
             }
 
             // 不要なフォルダを削除

--- a/Assets/uDesktopMascot/Editor/PostBuildProcessor.cs
+++ b/Assets/uDesktopMascot/Editor/PostBuildProcessor.cs
@@ -149,10 +149,10 @@ namespace uDesktopMascot.Editor
         }
 
         /// <summary>
-        ///     インストーラーのバージョンファイルを作成する
+        ///     setup.iss のバージョンをプロジェクトバージョンに更新する
         /// </summary>
         /// <param name="buildDirectory">ビルドディレクトリのパス</param>
-        private static void CreateInstallerSetupTextFile(string buildDirectory)
+        private static void UpdateSetupFileWithProjectVersion(string buildDirectory)
         {
             var projectVersion = PlayerSettings.bundleVersion;
 

--- a/Assets/uDesktopMascot/Editor/PostBuildProcessor.cs
+++ b/Assets/uDesktopMascot/Editor/PostBuildProcessor.cs
@@ -155,8 +155,31 @@ namespace uDesktopMascot.Editor
         private static void CreateInstallerSetupTextFile(string buildDirectory)
         {
             var projectVersion = PlayerSettings.bundleVersion;
-            var setupFilePath = Path.Combine(buildDirectory, "..", "..", "installer-setup.txt");
-            File.WriteAllText(setupFilePath, $"#define MyAppVersion \"{projectVersion}\"");
+
+            // setup.iss のパスを取得
+            var issFilePath = Path.Combine(buildDirectory, "..", "..", "setup.iss");
+            if (File.Exists(issFilePath))
+            {
+                // 行ごとに読み込み
+                var lines = File.ReadAllLines(issFilePath);
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    // #define MyAppVersion が含まれている行を探す
+                    // 前後に空白等があるかもしれないので Trim() して判定
+                    if (lines[i].Trim().StartsWith("#define MyAppVersion"))
+                    {
+                        // バージョン番号をプロジェクトバージョンに置き換える
+                        lines[i] = $"#define MyAppVersion \"{projectVersion}\"";
+                        break; // 最初に見つかった行だけ置換して抜ける
+                    }
+                }
+                // 上書き保存
+                File.WriteAllLines(issFilePath, lines);
+            }
+            else
+            {
+                Log.Warning($"setup.iss が見つかりません: {issFilePath}");
+            }
         }
 
         /// <summary>

--- a/setup.iss
+++ b/setup.iss
@@ -5,9 +5,9 @@
 #define MyAppPublisher "MidraLab"
 #define MyAppURL "https://midralab.github.io/uDesktopMascot/"
 #define MyAppExeName "uDesktopMascot.exe"
+#define MyAppVersion "0.1.0"
 
 [Setup]
-#include "installer-setup.txt"
 AppVersion={#MyAppVersion}
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)

--- a/setup.iss
+++ b/setup.iss
@@ -5,7 +5,7 @@
 #define MyAppPublisher "MidraLab"
 #define MyAppURL "https://midralab.github.io/uDesktopMascot/"
 #define MyAppExeName "uDesktopMascot.exe"
-#define MyAppVersion "0.1.0"
+#define MyAppVersion "0.2.0"
 
 [Setup]
 AppVersion={#MyAppVersion}

--- a/setup.iss
+++ b/setup.iss
@@ -5,7 +5,7 @@
 #define MyAppPublisher "MidraLab"
 #define MyAppURL "https://midralab.github.io/uDesktopMascot/"
 #define MyAppExeName "uDesktopMascot.exe"
-#define MyAppVersion "99.99.99"
+#define MyAppVersion "0.2.0"
 
 [Setup]
 AppVersion={#MyAppVersion}

--- a/setup.iss
+++ b/setup.iss
@@ -5,7 +5,7 @@
 #define MyAppPublisher "MidraLab"
 #define MyAppURL "https://midralab.github.io/uDesktopMascot/"
 #define MyAppExeName "uDesktopMascot.exe"
-#define MyAppVersion "0.2.0"
+#define MyAppVersion "0.1.0"
 
 [Setup]
 AppVersion={#MyAppVersion}


### PR DESCRIPTION
## 変更したこと
- setup.txtを削除しsetup.issの中身のバージョンを直接変更する形に変更
  - 通常のビルドワークフロー実行結果 https://github.com/MidraLab/uDesktopMascot/actions/runs/13085467626
- setup.txtをプッシュするワークフロー削除
- リリースワークフロー修正 
  - リリースアクションの実行結果 https://github.com/MidraLab/uDesktopMascot/actions/runs/13085291691/job/36515976676
  - v99.99.99 のドラフト https://github.com/MidraLab/uDesktopMascot/releases/tag/untagged-21df5d56abbf23e9ea17
- scheduleビルドがスキップされないようにした
  