### PR TITLE
パラメータ付きローカライズ文字列の更新方法を改良

### DIFF
--- a/Assets/uDesktopMascot/Prefab/ShowUpdate.prefab
+++ b/Assets/uDesktopMascot/Prefab/ShowUpdate.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 4467061708502604481}
   - component: {fileID: 974681114895473299}
   - component: {fileID: 1879611980268593842}
+  - component: {fileID: 4344575977041357685}
   m_Layer: 5
   m_Name: UpgradeText
   m_TagString: Untagged
@@ -136,6 +137,46 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &4344575977041357685
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 566293836550487321}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 56eb0353ae6e5124bb35b17aff880f16, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_StringReference:
+    m_TableReference:
+      m_TableCollectionName: GUID:e0bc4458d73676a429c1b840d5dbc577
+    m_TableEntryReference:
+      m_KeyId: 2499933916303360
+      m_Key: 
+    m_FallbackState: 0
+    m_WaitForCompletion: 0
+    m_LocalVariables: []
+  m_FormatArguments: []
+  m_UpdateString:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1879611980268593842}
+        m_TargetAssemblyTypeName: TMPro.TMP_Text, Unity.TextMeshPro
+        m_MethodName: set_text
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: 
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 1
+  references:
+    version: 2
+    RefIds: []
 --- !u!1 &597809613186944653
 GameObject:
   m_ObjectHideFlags: 0
@@ -252,7 +293,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   closeButton: {fileID: 6099873561876793913}
-  messageText: {fileID: 1879611980268593842}
+  latestVersionLocalizedStringEvent: {fileID: 4344575977041357685}
   skipShowUpgradeDialogToggle: {fileID: 7446035965173396997}
 --- !u!1 &920476251168917263
 GameObject:

--- a/Assets/uDesktopMascot/Scripts/Common/ShowUpdateDialog.cs
+++ b/Assets/uDesktopMascot/Scripts/Common/ShowUpdateDialog.cs
@@ -1,7 +1,5 @@
-﻿using System.Threading;
-using Cysharp.Threading.Tasks;
-using TMPro;
-using UnityEngine;
+﻿using UnityEngine;
+using UnityEngine.Localization.Components;
 using UnityEngine.UI;
 
 namespace uDesktopMascot
@@ -12,26 +10,15 @@ namespace uDesktopMascot
     public class ShowUpdateDialog : DialogBase
     {
         /// <summary>
-        /// メッセージテキスト
+        /// 最新バージョンのローカライズされた文字列イベント
         /// </summary>
-        [SerializeField] private TextMeshProUGUI messageText;
-        
+        [SerializeField] private LocalizeStringEvent latestVersionLocalizedStringEvent;
+
         /// <summary>
         /// アップグレードダイアログをスキップするかどうかのトグル
         /// </summary>
         [SerializeField] private Toggle skipShowUpgradeDialogToggle;
         
-        /// <summary>
-        /// キャンセルトークンソース
-        /// </summary>
-        private CancellationTokenSource _cancellationTokenSource;
-
-        private protected override void Awake()
-        {
-            base.Awake();
-            _cancellationTokenSource = new CancellationTokenSource();
-        }
-
         /// <summary>
         /// アップグレードダイアログをスキップするかどうか
         /// </summary>
@@ -42,22 +29,13 @@ namespace uDesktopMascot
         }
 
         /// <summary>
-        /// テーブル名の定数
-        /// </summary>
-        private const string TableName = "LocalizationTable";
-
-        /// <summary>
         /// メッセージを設定する
         /// </summary>
         /// <param name="latestVersion">最新バージョン番号</param>
-        /// <param name="cancellationToken"></param>
-        private async UniTask SetMessage(string latestVersion,CancellationToken cancellationToken)
+        private void SetMessage(string latestVersion)
         {
-            // LocalizationUtility を使用してローカライズされた文字列を同期的に取得
-            string message = await LocalizationUtility.GetLocalizedStringAsync(TableName, "MSG_NEW_VERSION",cancellationToken, latestVersion);
-
-            // メッセージテキストを更新
-            messageText.text = message;
+            latestVersionLocalizedStringEvent.StringReference.Arguments = new object[] {latestVersion};
+            latestVersionLocalizedStringEvent.StringReference.RefreshString();
         }
 
         /// <summary>
@@ -67,13 +45,7 @@ namespace uDesktopMascot
         public void Show(string latestVersion)
         {
             base.Show();
-            SetMessage(latestVersion,_cancellationTokenSource.Token).Forget();
-        }
-
-        private void OnDestroy()
-        {
-            _cancellationTokenSource?.Cancel();
-            _cancellationTokenSource?.Dispose();
+            SetMessage(latestVersion);
         }
     }
 }


### PR DESCRIPTION
ローカライズテーブルとエントリーが固定なのでLocalizedStringEventをアタッチして、スクリプトからバージョンをパラメータとして渡して更新のみを行うようにしています。
この方法は動的に言語を切り替えても反映されます。
